### PR TITLE
Remove duplicate redrawAll method

### DIFF
--- a/src/DriftmapEditor.js
+++ b/src/DriftmapEditor.js
@@ -302,11 +302,6 @@ class DriftmapEditor extends HTMLElement {
     this.lastDist = null;
   };
 
-  redrawAll() {
-    this.redrawLines();
-    this.renderPins();
-  }
-
   fitToAllPins() {
     if (this.pins.length === 0) return;
 


### PR DESCRIPTION
## Summary
- remove duplicated redrawAll function definition so only one remains at class end

## Testing
- ⚠️ `node src/DriftmapEditor.js` (fails: HTMLElement is not defined; DOM environment missing)


------
https://chatgpt.com/codex/tasks/task_e_68ac892edac8832bbdd1af4fb6f4414f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed a redundant internal method definition to eliminate duplication, improving code clarity and maintainability. No changes to behavior or user-facing features.
* **Chores**
  * Minor internal cleanup to reduce potential confusion during future development. No impact on performance or compatibility; no action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->